### PR TITLE
Implement proxified xmltv support

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -3,7 +3,7 @@
 # Either a file path or URL
 M3U_LOCATION =
 
-# Optional XMLTV URL
+# Optional XMLTV file path or URL
 XMLTV_LOCATION =
 
 # The port to add to the m3u file. If the app is running on port 80, you may not need this.
@@ -16,8 +16,8 @@ M3U_HOST =
 # The port that the app is listening on. If running locally, set it to the same value as M3U_PORT.
 LISTEN_PORT =
 
-# Use https instead of http for URLs (if you are behind a reverse proxy), True/False
-USE_HTTPS = True
+# Use https instead of http for URLs (if you are behind a reverse proxy), True or leave empty
+USE_HTTPS =
 
 # How often, in minutes, should the app pull the latest version of the m3u file.
-RELOAD_INTERVAL_MIN = 60
+RELOAD_INTERVAL_MIN =

--- a/config.ini
+++ b/config.ini
@@ -20,4 +20,4 @@ LISTEN_PORT =
 USE_HTTPS =
 
 # How often, in minutes, should the app pull the latest version of the m3u file.
-RELOAD_INTERVAL_MIN =
+RELOAD_INTERVAL_MIN = 60

--- a/config.ini
+++ b/config.ini
@@ -3,6 +3,9 @@
 # Either a file path or URL
 M3U_LOCATION =
 
+# Optional XMLTV URL
+XMLTV_LOCATION =
+
 # The port to add to the m3u file. If the app is running on port 80, you may not need this.
 M3U_PORT =
 
@@ -14,7 +17,7 @@ M3U_HOST =
 LISTEN_PORT =
 
 # Use https instead of http for URLs (if you are behind a reverse proxy), True/False
-USE_HTTPS =
+USE_HTTPS = True
 
 # How often, in minutes, should the app pull the latest version of the m3u file.
 RELOAD_INTERVAL_MIN = 60

--- a/proxy.py
+++ b/proxy.py
@@ -62,6 +62,15 @@ def data(path):
 
     return Response(response=response.content, headers=return_headers, status=HTTPStatus.OK)
 
+@app.route('/proxy/xmltv')
+def xmltv():
+    """
+    Used for fetching XMLTV (EPG) data through the proxy.
+    Unlike stream(), this does not return a streamed response.
+    """
+    url = get_variable(config, 'XMLTV_LOCATION') 
+    return data(url) if url else ''
+
 @app.route('/proxy/reload', methods=['GET'])
 def reload():
     """

--- a/xmltv.py
+++ b/xmltv.py
@@ -1,0 +1,39 @@
+from http import HTTPStatus
+import parser
+import os
+import re
+import requests
+
+class Xmltv:
+    def fetch_xmltv(self, xmltv_location: str, host:str, port: int, use_https: bool, output_path: str):
+        """
+        Get the xmltv from either a file location or through a web request.
+        The xmltv file will be saved as /static/epg.xml so your IPTV player can access it.
+        """
+
+        content = str()
+        url_parser = parser.Parser()
+        
+        if url_parser.is_url(xmltv_location):
+            headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
+            response = requests.get(xmltv_location, headers=headers)
+
+            if response.status_code != HTTPStatus.OK:
+                raise Exception(response.text)
+
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+            content = response.text
+        else:
+            with open(xmltv_location, 'r') as input:
+                os.makedirs(os.path.dirname(output_path), exist_ok=True)
+                content = input.read()
+
+        with open(str(output_path), 'w') as output:
+
+            port_str = f':{str(port)}' if port != 0 else ''
+            
+            # Prefix all URLs in the xml file with the proxy endpoints.
+            content = re.sub(r'(http|https)', rf'http://{host}{port_str}/proxy/data/\1', content, flags=re.M)
+            if use_https == True:
+                content = re.sub(rf'(http://{host})',rf'https://{host}', content, flags=re.M)        
+            output.write(content)


### PR DESCRIPTION
- Implements a static "/static/epg.xml" location that can be optionally configured to point to a URL or local file, implemented in a manner similar to the existing parser.
- Currently called alongside m3u reloads